### PR TITLE
Update ZiGate-Ethernet.ino with values for Home Assistant ZHA discovery via mDNS Zeroconf

### DIFF
--- a/ZiGate-Ethernet.ino
+++ b/ZiGate-Ethernet.ino
@@ -337,7 +337,6 @@ void setup(void)
   MDNS.addService("zigate_zigbee_gateway", "tcp", 9999);
   MDNS.addServiceTxt("zigate_zigbee_gateway", "tcp", "radio_type", "zigate");
   MDNS.addServiceTxt("zigate_gateway", "tcp", "baud_rate", "115200");
-  MDNS.addServiceTxt("zigate_gateway", "tcp", "port", "9999");
   MDNS.addServiceTxt("zigate_gateway", "tcp", "data_flow_control", "software");
 
   //Config PiZiGate

--- a/ZiGate-Ethernet.ino
+++ b/ZiGate-Ethernet.ino
@@ -334,10 +334,11 @@ void setup(void)
      //return;
   }
 
-  MDNS.addService("zigbee_gateway", "tcp", 9999);
-  MDNS.addServiceTxt("zigbee_gateway", "tcp", "radio_type", "zigate");
-  MDNS.addServiceTxt("zigbee_gateway", "tcp", "baud_rate", "115200");
-  MDNS.addServiceTxt("zigbee_gateway", "tcp", "tcp_port_serial_gateway", "9999");
+  MDNS.addService("zigate_zigbee_gateway", "tcp", 9999);
+  MDNS.addServiceTxt("zigate_zigbee_gateway", "tcp", "radio_type", "zigate");
+  MDNS.addServiceTxt("zigate_gateway", "tcp", "baud_rate", "115200");
+  MDNS.addServiceTxt("zigate_gateway", "tcp", "port", "9999");
+  MDNS.addServiceTxt("zigate_gateway", "tcp", "data_flow_control", "software");
 
   //Config PiZiGate
   pinMode(RESET_ZIGATE, OUTPUT);


### PR DESCRIPTION
@fairecasoimeme as per https://github.com/fairecasoimeme/ZiGate-Ethernet/issues/7 this blind attempt adds missing DNS TXT records values needed for Zeroconf discovery in ZHA.

https://www.home-assistant.io/integrations/zha/#discovery-via-usb-or-zeroconf

Also note that I changed the service name to contain word "**_zigate_**" which will be needed as an identifier for ZiGate gateways.

So this is my attempt at updating ZiGate-Ethernet.ino with values for Home Assistant ZHA discovery via mDNS Zeroconf. 

Please understand that I own a ZiGate-Ethernet to test it myself so I can not test this (I am just a fan of ZHA's auto-discovery).

This is a back-port of the mDNS code that  @xyzroe and @mercenaruss is working on for ZigStar-Gateway firmware (which in turn is a fork of ZiGate-Ethernet firmware):

https://github.com/xyzroe/ZigStarGW-FW/issues/3

https://github.com/xyzroe/ZigStarGW-FW/blob/fd41317584758333786d26592d24b3d90a0e60d2/src/main.cpp#L648-L652

Other than the service name really need to start with "zigate*" as a unique identifier, these values is needed via TXT records:

* radio_type=zigate
* baud_rate=115200
* data_flow_control=software

@fairecasoimeme I assumed ZiGate Zigbee radio uses software flow control but maybe it use hardware or no flow control? Could be that flow control parameter for serial communication needs to be set to `hardware` or `none` instead of `software`?

Anyway; hostname, service, port, are the minimum TXT records needed for Home Assistant ZHA discovery via mDNS Zeroconf.

If wanted could add additional TXT records for information, like version and location, (some ESPHome based gateways do so).

You should be able to test ZiGate results obtained with `avahi-browse -a -r` so can see that txt format and info looks correct.

Result from `avahi-browse -a -r` should be compatible with ZHA integration in Home Assistant if they look something like:

 ```
_zigate_zigbee_gateway._tcp      local
   hostname = [zigate_zigbee_gateway.local]
   address = [192.168.0.174]
   port = [9999]
   txt = ["radio_type=zigate" "baud_rate=115200" "data_flow_control=software"]
 ```

Once those values are available to Zeroconf via DNS TXT records can submit patch for ZiGate-Ethernet to Home Assistant core:

https://github.com/home-assistant/core/blob/dev/homeassistant/generated/zeroconf.py

https://github.com/home-assistant/core/blob/dev/homeassistant/components/zha/manifest.json

See example for ` "tube*"`  as used for ` "domain": "zha"`  in those two files which could be copied and replaced with zigate info:

https://github.com/home-assistant/core/blob/dev/homeassistant/generated/zeroconf.py#L79

 ```
    "_zigate_zigbee_gateway._tcp.local.": [
        {
            "domain": "zha",
            "name": "zigate*"
        }
    ],
 ```

https://github.com/home-assistant/core/blob/dev/homeassistant/components/zha/manifest.json#L26

 ```
    {
      "type": "_zigate_zigbee_gateway._tcp.local.",
      "name": "zigate*"
    }
 ```
Plus think also need to add `zigate` to ZHA config flow as that currently look to only support `ezsp` and `znp` radio types, or?

https://github.com/home-assistant/core/blob/dev/homeassistant/components/zha/config_flow.py#L190

```
        self._radio_type = (
            RadioType.ezsp.name if "efr32" in local_name else RadioType.znp.name
        )

```

@doudz Can you maybe help test Conditions and If statements for adding `RadioType.zigate.name` with another `else`? Like:

```
        self._radio_type = (
            RadioType.ezsp.name if "efr32" in local_name else RadioType.zigate.name if "zigate" in local_name else RadioType.znp.name
        )

```